### PR TITLE
Aplicación del Patron Creacional: Singleton

### DIFF
--- a/src/Logica/Conexion.java
+++ b/src/Logica/Conexion.java
@@ -6,25 +6,28 @@ import java.sql.SQLException;
 import javax.swing.JOptionPane;
 
 public class Conexion {
-    
-    public Conexion() {
-        
+    private static Conexion instancia;
+    private Connection link;
+
+    private Conexion() {
+        // Constructor privado para evitar instancias directas
     }
 
-    public Connection Conectar(){
-        Connection link = null;
-        
-        try{
-            
-            //sistema_informacion_cultural
-            Class.forName("com.mysql.jdbc.Driver");
-            link = DriverManager.getConnection("jdbc:mysql://localhost/sistema_informacion_cultural?user=root&password=1234&useSSL=false");                      
+    public static Conexion obtenerInstancia() {
+        if (instancia == null) {
+            instancia = new Conexion();
         }
-        catch(ClassNotFoundException | SQLException e){
+        return instancia;
+    }
+
+    public Connection Conectar() {
+        try {
+            Class.forName("com.mysql.jdbc.Driver");
+            link = DriverManager.getConnection("jdbc:mysql://localhost/sistema_informacion_cultural?user=root&password=1234&useSSL=false");
+        } catch (ClassNotFoundException | SQLException e) {
             JOptionPane.showConfirmDialog(null, e);
         }
-        
         return link;
     }
-    
 }
+


### PR DESCRIPTION
Se agregó un atributo estático y privado instancia para almacenar la única instancia de la clase Conexion.

Se creó un constructor privado para evitar instancias directas de la clase desde fuera de la misma.

Se implementó un método estático obtenerInstancia() que se encarga de crear la instancia única de Conexion si aún no existe o devolver la instancia existente si ya ha sido creada.

Se modificó el método Conectar() para obtener la conexión a la base de datos. Se verificó si ya existe una conexión (link == null) antes de crear una nueva. Si ya existe una conexión, se devuelve la conexión existente en lugar de crear una nueva.

Al utilizar el patrón Singleton, ahora siempre trabajamos con la misma instancia de la clase Conexion, lo que garantiza que tengamos una única conexión a la base de datos en toda la aplicación.